### PR TITLE
perf: 增加 _err 文件夹支持，增加 c2y 惩罚，增加去重脚本，支持自动根据训练集数量计算权重

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ output
 fonts
 pretrained_model
 
+/.vs
+/.vscode

--- a/combat/skill_ready/README.md
+++ b/combat/skill_ready/README.md
@@ -21,6 +21,8 @@ skill_ready/
 │   ├── loss.py             # 损失函数实现
 │   └── path_manager.py     # 路径管理工具
 ├── train.py                # 训练脚本
+├── split_dataset.py        # 从训练集划分验证集
+├── deduplicate_dataset.py  # 对相似截图做哈希去重
 ├── validate.py             # PyTorch模型验证
 ├── export.py               # ONNX模型导出
 ├── onnx_inference.py       # ONNX模型验证
@@ -45,7 +47,10 @@ datasets/
 ├── train/   # 训练集
 │   ├── c
 │   ├── n
-│   └── y
+│   ├── y
+│   ├── c_err   # 可选: 历史误判但真实标签为 c 的难例
+│   ├── n_err   # 可选: 历史误判但真实标签为 n 的难例
+│   └── y_err   # 可选: 历史误判但真实标签为 y 的难例
 └── val/     # 验证集
     ├── c
     ├── n
@@ -54,32 +59,66 @@ datasets/
 
 支持的图像格式：`.png`, `.jpg`, `.jpeg`
 
+训练时会将 `*_err` 目录映射回对应原类别，并按配置中的 `training.sampler.err_folder_weight` 提高采样权重，用于难例增强。
+
 ### 3. 模型训练
 
 ```bash
+# 先对训练集去重，重复图会被移到单独目录
+python deduplicate_dataset.py --input_dir datasets/train --duplicates_dir datasets/duplicates/train --distance_threshold 4 --clear_duplicates
+
+# 从训练集抽取 10% 到验证集
+python split_dataset.py --train_dir datasets/train --val_dir datasets/val --val_ratio 0.1 --clear_val
+
 # 使用MobileNetV4小模型训练
 python train.py --config configs/mobilenetv4_conv_small.yaml
+
+# 在上一次训练结果基础上继续微调
+python train.py --config configs/mobilenetv4_conv_small.yaml --weights checkpoints/mobilenetv4_conv_small/skill_ready_cls.pth
 ```
 
+`split_dataset.py` 支持直接读取 `train` 下的 `c/n/y/c_err/n_err/y_err` 六个目录，并在划分时按真实标签归并到 `val/c`、`val/n`、`val/y`。
+默认会复制文件，适合你按版本保留训练集与验证集各一份；如果你确实要把样本从 train 抽走到 val，可以加 `--move`。
+
+`deduplicate_dataset.py` 会对 `train` 下的 `c/n/y/c_err/n_err/y_err` 六个目录按真实标签分组做 dHash 去重，只在同一真实类别内比较相似度，避免跨类误删。重复图片会被移动到单独的 `duplicates` 目录，并保留原始来源子目录；去重明细会写入 `dedup_report.tsv`。
+默认阈值是 4，适合处理短时间连续截图导致的高度相似样本；如果发现去重过严或过松，可以调 `--distance_threshold`。
+
+推荐迭代方式：当前版本收集两份新数据，一份直接补到 `train`，一份单独补到 `val`；等下一批新数据到来后，再把上一轮 `val` 中已经看过的样本并回 `train`，重新划一轮新的验证集。
+
+如果是增量数据微调，可以直接传 `--weights` 加载上一版模型权重作为起点；当前实现不会恢复历史 epoch 和优化器状态，只做轻量热启动。
+
 ### 4. 模型验证
+
+验证阶段的 `Accuracy` 会按验证集自身的类别数量做直接反比加权，也就是少样本类权重更高；这里使用的是验证集原始比例，不使用训练阶段的 `1/sqrt(样本数)` 权重。
 
 ```bash
 # PyTorch模型验证
 python validate.py --config configs/mobilenetv4_conv_small.yaml --val_path datasets/val
+
+# 将误判样本直接回灌到训练集的 *_err 目录
+python validate.py --config configs/mobilenetv4_conv_small.yaml --val_path datasets/val --hard_example_dir datasets/train
 ```
 
 ### 5. 模型导出
 
 ```bash
-# 导出为ONNX格式
+# 默认加载 checkpoints/{model_name}/skill_ready_cls.pth 后导出为 ONNX
 python export.py --config configs/mobilenetv4_conv_small.yaml
+
+# 显式指定要导出的 pth 权重
+python export.py --config configs/mobilenetv4_conv_small.yaml --weights checkpoints/mobilenetv4_conv_small/skill_ready_cls.pth
 ```
+
+`export.py` 在导出前会先加载 `.pth` 权重。默认加载 `checkpoints/{model_name}/skill_ready_cls.pth`，也可以通过 `--weights` 指定其他权重文件。
 
 ### 6. ONNX模型验证
 
 ```bash
 # ONNX模型验证和性能测试
 python onnx_inference.py --config configs/mobilenetv4_conv_small.yaml --val_path datasets/val
+
+# 导出误判样本到训练集的 *_err 目录
+python onnx_inference.py --config configs/mobilenetv4_conv_small.yaml --val_path datasets/val --hard_example_dir datasets/train
 ```
 
 ## 配置说明
@@ -99,6 +138,7 @@ python onnx_inference.py --config configs/mobilenetv4_conv_small.yaml --val_path
 - `optimizer`: 优化器配置（类型、学习率、权重衰减）
 - `use_cuda_amp`: 启用混合精度训练
 - `loss`: 损失函数类型（'focal' 或 'CE'）
+- `loss.class_weight.enabled`: 是否按训练集文件数量自动启用类别权重；当前采用更温和的 `1/sqrt(样本数)` 方式
 
 ### 数据配置
 - `dataset_path`: 数据集目录路径
@@ -131,10 +171,11 @@ python onnx_inference.py --config configs/mobilenetv4_conv_small.yaml --val_path
 ### 导出流程
 
 #### 导出流程
-参考文件: `export.py`
+参考文件: `export.py` 与 `export.md`
 
 - **加载配置文件**: 获取模型配置
 - **创建模型实例**
+- **加载 `.pth` 权重**: 默认读取 `checkpoints/{model_name}/skill_ready_cls.pth`，也可用 `--weights` 覆盖
 - **导出 ONNX 模型**: 使用 `torch.onnx.export()` 导出 ONNX 模型
-  - **注意**: 导出的函数中务必加载 `.pth` 权重，否则导出的 ONNX 模型将只是初始化状态
+  - **注意**: 如果不加载 `.pth` 权重，导出的 ONNX 模型只会是初始化状态
 

--- a/combat/skill_ready/README.md
+++ b/combat/skill_ready/README.md
@@ -89,7 +89,7 @@ python train.py --config configs/mobilenetv4_conv_small.yaml --weights checkpoin
 
 ### 4. 模型验证
 
-验证阶段的 `Accuracy` 会按验证集自身的类别数量做直接反比加权，也就是少样本类权重更高；这里使用的是验证集原始比例，不使用训练阶段的 `1/sqrt(样本数)` 权重。
+验证阶段的 `Accuracy` 会按验证集自身的类别数量做直接反比加权；如果样本来自 `*_err` 目录，还会额外乘上与训练相同的 `training.sampler.err_folder_weight`。
 
 ```bash
 # PyTorch模型验证
@@ -164,7 +164,10 @@ python onnx_inference.py --config configs/mobilenetv4_conv_small.yaml --val_path
 ### 训练输出
 - **检查点**: 保存在 `checkpoints/{model_name}/`
 - **日志**: TensorBoard日志保存在 `logs/train/{model_name}/`
+- **图形化报告**: 训练曲线、混淆矩阵、每类 Precision/Recall/F1 柱状图保存在对应日志目录
 - **最佳模型**: `skill_ready_cls.pth`
+
+训练、验证、ONNX 验证结束后，控制台会直接打印报告目录以及 `classification_report.txt`、`val_confusion_matrix.png`、`val_classification_metrics.png` 等文件路径。
 
 ### ONNX输出
 - **ONNX模型**: `onnx/{model_name}/skill_ready_cls.onnx`

--- a/combat/skill_ready/README.md
+++ b/combat/skill_ready/README.md
@@ -137,6 +137,8 @@ python onnx_inference.py --config configs/mobilenetv4_conv_small.yaml --val_path
 - `epochs`: 训练轮数
 - `optimizer`: 优化器配置（类型、学习率、权重衰减）
 - `use_cuda_amp`: 启用混合精度训练
+- `lr_scheduler`: 当前支持带 warmup 的 cosine 调度，训练中会实际生效
+- `early_stopping`: 按验证集加权准确率提前停止训练
 - `loss`: 损失函数类型（'focal' 或 'CE'）
 - `loss.class_weight.enabled`: 是否按训练集文件数量自动启用类别权重；当前采用更温和的 `1/sqrt(样本数)` 方式
 

--- a/combat/skill_ready/README.md
+++ b/combat/skill_ready/README.md
@@ -90,6 +90,7 @@ python train.py --config configs/mobilenetv4_conv_small.yaml --weights checkpoin
 ### 4. 模型验证
 
 验证阶段的 `Accuracy` 会按验证集自身的类别数量做直接反比加权，不会因为样本来自 `*_err` 目录而额外提高权重。
+Python 侧验证与训练中的验证集评估现在会复用 Maa 实跑同款前处理：先把输入从 `64x64` 放大到 `72x72`，再中心裁回 `64x64`，最后再做归一化。
 
 ```bash
 # PyTorch模型验证

--- a/combat/skill_ready/README.md
+++ b/combat/skill_ready/README.md
@@ -89,7 +89,7 @@ python train.py --config configs/mobilenetv4_conv_small.yaml --weights checkpoin
 
 ### 4. 模型验证
 
-验证阶段的 `Accuracy` 会按验证集自身的类别数量做直接反比加权；如果样本来自 `*_err` 目录，还会额外乘上与训练相同的 `training.sampler.err_folder_weight`。
+验证阶段的 `Accuracy` 会按验证集自身的类别数量做直接反比加权，不会因为样本来自 `*_err` 目录而额外提高权重。
 
 ```bash
 # PyTorch模型验证

--- a/combat/skill_ready/configs/mobilenetv4_conv_small.yaml
+++ b/combat/skill_ready/configs/mobilenetv4_conv_small.yaml
@@ -8,8 +8,17 @@ model:
 training:
   batch_size: 256
   epochs: 30
+  sampler:
+    use_weighted_sampler: true
+    err_folder_weight: 3.0
   loss:
     type: "focal" # focal / CE
+    class_weight:
+      enabled: true
+    confusion_penalty:
+      enabled: true
+      weight: 0.75
+      c_to_y: 2.5
   optimizer:
     type: "AdamW"
     lr: 1e-5
@@ -22,5 +31,6 @@ training:
 
 data:
   dataset_path: datasets/train
+  val_dataset_path: datasets/val
   input_size: 64
   split_ratio: 0.9

--- a/combat/skill_ready/configs/mobilenetv4_conv_small.yaml
+++ b/combat/skill_ready/configs/mobilenetv4_conv_small.yaml
@@ -28,6 +28,12 @@ training:
   lr_scheduler:
     type: "cosine"
     warmup_epochs: 5
+    min_lr: 1e-6
+
+  early_stopping:
+    enabled: true
+    patience: 5
+    min_delta: 0.001
 
 data:
   dataset_path: datasets/train

--- a/combat/skill_ready/configs/mobilenetv4_conv_small.yaml
+++ b/combat/skill_ready/configs/mobilenetv4_conv_small.yaml
@@ -32,8 +32,8 @@ training:
 
   early_stopping:
     enabled: true
-    patience: 5
-    min_delta: 0.001
+    patience: 8
+    min_delta: 0.0003
 
 data:
   dataset_path: datasets/train

--- a/combat/skill_ready/core/base_model.py
+++ b/combat/skill_ready/core/base_model.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 from torchvision import transforms
 from abc import ABC, abstractmethod
+from core.data_loader import get_class_counts
 
 class BaseModel(ABC, nn.Module):
     def __init__(self, config):
@@ -19,14 +20,10 @@ class BaseModel(ABC, nn.Module):
     def setup_class_weights(self):
         # 动态计算类别权重
         dataset_path = self.config['data']['dataset_path']
-        class_names = os.listdir(dataset_path)
-        class_counts = []
-        for class_name in class_names:
-            class_dir = os.path.join(dataset_path, class_name)
-            class_counts.append(len(os.listdir(class_dir)))
-        class_counts = torch.tensor(class_counts).float()
-        self.class_weights = 1.0 / class_counts
-        self.class_weights /= self.class_weights.sum()
+        class_counts = get_class_counts(dataset_path, self.class_names).clamp_min(1.0)
+        self.class_counts = class_counts
+        sqrt_counts = torch.sqrt(class_counts)
+        self.class_weights = class_counts.sum() / (sqrt_counts.sum() * sqrt_counts)
 
     def setup_transforms(self):
         # 训练集增强流程
@@ -36,26 +33,34 @@ class BaseModel(ABC, nn.Module):
                 scale=(0.8, 1.0),
                 interpolation=transforms.InterpolationMode.BICUBIC
             ),
+            transforms.RandomAffine(
+                degrees=0,
+                translate=(0.12, 0.12),
+                scale=(0.9, 1.1),
+                interpolation=transforms.InterpolationMode.BICUBIC
+            ),
             transforms.RandomHorizontalFlip(p=0.5),
             transforms.ColorJitter(
                 brightness=0.2,
                 contrast=0.2,
                 saturation=0.2
             ),
+            transforms.ToTensor(),
             transforms.RandomErasing(
                 p=0.5,
                 scale=(0.02, 0.2),
                 ratio=(0.3, 3.3)
             ),
-            transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                  std=[0.229, 0.224, 0.225])
         ])
 
         # 验证集转换流程
         self.val_transform = transforms.Compose([
-            transforms.Resize(72),
-            transforms.CenterCrop(self.config['data']['input_size']),
+            transforms.Resize(
+                (self.config['data']['input_size'], self.config['data']['input_size']),
+                interpolation=transforms.InterpolationMode.BICUBIC
+            ),
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                  std=[0.229, 0.224, 0.225])

--- a/combat/skill_ready/core/base_model.py
+++ b/combat/skill_ready/core/base_model.py
@@ -25,7 +25,21 @@ class BaseModel(ABC, nn.Module):
         sqrt_counts = torch.sqrt(class_counts)
         self.class_weights = class_counts.sum() / (sqrt_counts.sum() * sqrt_counts)
 
+    def _resolve_square_input_size(self):
+        input_size = self.config['data']['input_size']
+        if isinstance(input_size, int):
+            return input_size
+        if isinstance(input_size, (list, tuple)):
+            if len(input_size) == 1:
+                return int(input_size[0])
+            if len(input_size) == 2 and int(input_size[0]) == int(input_size[1]):
+                return int(input_size[0])
+        raise ValueError(f"仅支持方形 input_size，当前配置为: {input_size}")
+
     def setup_transforms(self):
+        input_size = self._resolve_square_input_size()
+        runtime_resize_size = int(round(input_size * 72 / 64))
+
         # 训练集增强流程
         self.train_transform = transforms.Compose([
             transforms.RandomResizedCrop(
@@ -55,12 +69,13 @@ class BaseModel(ABC, nn.Module):
                                  std=[0.229, 0.224, 0.225])
         ])
 
-        # 验证集转换流程
+        # 与 Maa 实跑对齐：先放大到 72，再中心裁到 64。
         self.val_transform = transforms.Compose([
             transforms.Resize(
-                (self.config['data']['input_size'], self.config['data']['input_size']),
+                (runtime_resize_size, runtime_resize_size),
                 interpolation=transforms.InterpolationMode.BICUBIC
             ),
+            transforms.CenterCrop(input_size),
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                  std=[0.229, 0.224, 0.225])

--- a/combat/skill_ready/core/data_loader.py
+++ b/combat/skill_ready/core/data_loader.py
@@ -130,6 +130,19 @@ def _extract_hard_case_flags(dataset):
     return dataset.sample_is_hard_case
 
 
+def get_dataset_sample_weights(dataset, num_classes, err_folder_weight=1.0):
+    labels = torch.tensor(_extract_labels(dataset), dtype=torch.long)
+    class_weights = get_dataset_class_weights(dataset, num_classes)
+    sample_weights = class_weights[labels]
+
+    hard_case_flags = torch.tensor(_extract_hard_case_flags(dataset), dtype=torch.bool)
+    if err_folder_weight > 1.0:
+        sample_weights = sample_weights.clone()
+        sample_weights[hard_case_flags] *= float(err_folder_weight)
+
+    return sample_weights
+
+
 def _build_weighted_sampler(dataset, err_folder_weight=1.0):
     labels = torch.tensor(_extract_labels(dataset), dtype=torch.long)
     class_counts = torch.bincount(labels).float().clamp_min(1.0)

--- a/combat/skill_ready/core/data_loader.py
+++ b/combat/skill_ready/core/data_loader.py
@@ -1,24 +1,79 @@
-import torch
-from torch.utils.data import DataLoader, Dataset
-from PIL import Image
 import os
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader, Dataset, Subset, WeightedRandomSampler
+
+
+DEFAULT_CLASS_NAMES = ('c', 'n', 'y')
+ERR_SUFFIX = '_err'
+
+
+def resolve_canonical_class_name(folder_name, class_names=None, err_suffix=ERR_SUFFIX):
+    class_names = tuple(class_names or DEFAULT_CLASS_NAMES)
+    if folder_name in class_names:
+        return folder_name, False
+
+    if folder_name.endswith(err_suffix):
+        base_name = folder_name[:-len(err_suffix)]
+        if base_name in class_names:
+            return base_name, True
+
+    return None, False
+
+
+def get_class_counts(root_dir, class_names=None, err_suffix=ERR_SUFFIX):
+    class_names = list(class_names or DEFAULT_CLASS_NAMES)
+    class_to_idx = {cls: index for index, cls in enumerate(class_names)}
+    class_counts = torch.zeros(len(class_names), dtype=torch.float32)
+
+    for folder_name in sorted(os.listdir(root_dir)):
+        class_dir = os.path.join(root_dir, folder_name)
+        if not os.path.isdir(class_dir):
+            continue
+
+        canonical_name, _ = resolve_canonical_class_name(folder_name, class_names, err_suffix)
+        if canonical_name is None:
+            continue
+
+        image_count = sum(
+            1 for filename in os.listdir(class_dir)
+            if filename.lower().endswith(('.png', '.jpg', '.jpeg'))
+        )
+        class_counts[class_to_idx[canonical_name]] += image_count
+
+    return class_counts
 
 class SkillIconDataset(Dataset):
-    def __init__(self, root_dir, transform=None):
+    def __init__(self, root_dir, transform=None, class_names=None, err_suffix=ERR_SUFFIX):
         self.root_dir = root_dir
         self.transform = transform
-        self.classes = sorted(os.listdir(root_dir))
+        self.class_names = list(class_names or DEFAULT_CLASS_NAMES)
+        self.err_suffix = err_suffix
+        self.classes = list(self.class_names)
         self.class_to_idx = {cls: i for i, cls in enumerate(self.classes)}
+        self.sample_is_hard_case = []
         self.samples = self._make_dataset()
 
     def _make_dataset(self):
         instances = []
-        for class_name in self.classes:
-            class_dir = os.path.join(self.root_dir, class_name)
-            for filename in os.listdir(class_dir):
+        for folder_name in sorted(os.listdir(self.root_dir)):
+            class_dir = os.path.join(self.root_dir, folder_name)
+            if not os.path.isdir(class_dir):
+                continue
+
+            class_name, is_hard_case = resolve_canonical_class_name(
+                folder_name,
+                self.class_names,
+                self.err_suffix
+            )
+            if class_name is None:
+                continue
+
+            for filename in sorted(os.listdir(class_dir)):
                 if filename.lower().endswith(('.png', '.jpg', '.jpeg')):
                     path = os.path.join(class_dir, filename)
                     instances.append((path, self.class_to_idx[class_name]))
+                    self.sample_is_hard_case.append(is_hard_case)
         return instances
 
     def __len__(self):
@@ -31,30 +86,113 @@ class SkillIconDataset(Dataset):
             image = self.transform(image)
         return image, label
 
+
+def _stratified_split_indices(samples, split_ratio, seed=42):
+    label_to_indices = {}
+    for index, (_, label) in enumerate(samples):
+        label_to_indices.setdefault(label, []).append(index)
+
+    generator = torch.Generator().manual_seed(seed)
+    train_indices = []
+    val_indices = []
+
+    for label in sorted(label_to_indices):
+        indices = label_to_indices[label]
+        shuffled = [indices[i] for i in torch.randperm(len(indices), generator=generator).tolist()]
+        train_size = int(len(shuffled) * split_ratio)
+        train_indices.extend(shuffled[:train_size])
+        val_indices.extend(shuffled[train_size:])
+
+    return train_indices, val_indices
+
+
+def _extract_labels(dataset):
+    if isinstance(dataset, Subset):
+        return [dataset.dataset.samples[index][1] for index in dataset.indices]
+    return [label for _, label in dataset.samples]
+
+
+def get_dataset_class_counts(dataset, num_classes):
+    labels = torch.tensor(_extract_labels(dataset), dtype=torch.long)
+    return torch.bincount(labels, minlength=num_classes).float()
+
+
+def get_dataset_class_weights(dataset, num_classes):
+    class_counts = get_dataset_class_counts(dataset, num_classes)
+    safe_counts = class_counts.clamp_min(1.0)
+    total_samples = class_counts.sum().clamp_min(1.0)
+    return total_samples / (len(class_counts) * safe_counts)
+
+
+def _extract_hard_case_flags(dataset):
+    if isinstance(dataset, Subset):
+        return [dataset.dataset.sample_is_hard_case[index] for index in dataset.indices]
+    return dataset.sample_is_hard_case
+
+
+def _build_weighted_sampler(dataset, err_folder_weight=1.0):
+    labels = torch.tensor(_extract_labels(dataset), dtype=torch.long)
+    class_counts = torch.bincount(labels).float().clamp_min(1.0)
+    class_weights = class_counts.reciprocal()
+
+    hard_case_flags = torch.tensor(_extract_hard_case_flags(dataset), dtype=torch.bool)
+    hard_case_weights = torch.ones(len(labels), dtype=torch.float32)
+    if err_folder_weight > 1.0:
+        hard_case_weights[hard_case_flags] = float(err_folder_weight)
+
+    sample_weights = class_weights[labels] * hard_case_weights
+    return WeightedRandomSampler(
+        weights=sample_weights.double(),
+        num_samples=len(sample_weights),
+        replacement=True
+    )
+
+
 def create_loaders(config, train_transform, val_transform):
-    # 创建完整数据集
-    full_dataset = SkillIconDataset(
-        root_dir=config['data']['dataset_path'],
-        transform=train_transform
-    )
+    train_root = config['data']['dataset_path']
+    val_root = config['data'].get('val_dataset_path')
 
-    # 按配置文件比例拆分数据集
-    split_ratio = config['data']['split_ratio']
-    train_size = int(split_ratio * len(full_dataset))
-    val_size = len(full_dataset) - train_size
-    train_dataset, val_dataset = torch.utils.data.random_split(
-        full_dataset, [train_size, val_size],
-        generator=torch.Generator().manual_seed(42)
-    )
+    if val_root and os.path.isdir(val_root):
+        train_dataset = SkillIconDataset(
+            root_dir=train_root,
+            transform=train_transform
+        )
+        val_dataset = SkillIconDataset(
+            root_dir=val_root,
+            transform=val_transform
+        )
+    else:
+        full_dataset = SkillIconDataset(root_dir=train_root, transform=None)
+        split_ratio = config['data']['split_ratio']
+        train_indices, val_indices = _stratified_split_indices(
+            full_dataset.samples,
+            split_ratio,
+            seed=42
+        )
+        train_dataset = Subset(
+            SkillIconDataset(root_dir=train_root, transform=train_transform),
+            train_indices
+        )
+        val_dataset = Subset(
+            SkillIconDataset(root_dir=train_root, transform=val_transform),
+            val_indices
+        )
 
-    # 设置验证集转换
-    val_dataset.dataset.transform = val_transform
+    sampler_config = config['training'].get('sampler', {})
+    train_sampler = None
+    if sampler_config.get('use_weighted_sampler', False):
+        err_folder_weight = float(sampler_config.get('err_folder_weight', 1.0))
+        train_sampler = _build_weighted_sampler(
+            train_dataset,
+            err_folder_weight=err_folder_weight
+        )
 
     # 创建数据加载器
     train_loader = DataLoader(
         train_dataset,
         batch_size=config['training']['batch_size'],
-        shuffle=True,
+        shuffle=train_sampler is None,
+        sampler=train_sampler,
         num_workers=4,
         pin_memory=True
     )

--- a/combat/skill_ready/deduplicate_dataset.py
+++ b/combat/skill_ready/deduplicate_dataset.py
@@ -1,0 +1,254 @@
+import argparse
+import os
+import shutil
+
+from PIL import Image, UnidentifiedImageError
+
+from core.data_loader import DEFAULT_CLASS_NAMES, resolve_canonical_class_name
+
+
+IMAGE_EXTENSIONS = ('.png', '.jpg', '.jpeg')
+RESAMPLE = Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS
+
+
+class BKTreeNode:
+    def __init__(self, hash_value, sample):
+        self.hash_value = hash_value
+        self.sample = sample
+        self.children = {}
+
+
+class BKTree:
+    def __init__(self):
+        self.root = None
+
+    def add(self, hash_value, sample):
+        if self.root is None:
+            self.root = BKTreeNode(hash_value, sample)
+            return
+
+        node = self.root
+        while True:
+            distance = hamming_distance(hash_value, node.hash_value)
+            child = node.children.get(distance)
+            if child is None:
+                node.children[distance] = BKTreeNode(hash_value, sample)
+                return
+            node = child
+
+    def query(self, hash_value, max_distance):
+        if self.root is None:
+            return None, None
+
+        best_node = None
+        best_distance = max_distance + 1
+        stack = [self.root]
+
+        while stack:
+            node = stack.pop()
+            distance = hamming_distance(hash_value, node.hash_value)
+            if distance <= max_distance and distance < best_distance:
+                best_node = node
+                best_distance = distance
+
+            lower = distance - max_distance
+            upper = distance + max_distance
+            for child_distance, child in node.children.items():
+                if lower <= child_distance <= upper:
+                    stack.append(child)
+
+        return best_node, best_distance if best_node is not None else None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Deduplicate similar screenshots with perceptual hash')
+    parser.add_argument('--input_dir', default='datasets/train', type=str, help='输入数据目录，支持 c/n/y 和 *_err')
+    parser.add_argument('--duplicates_dir', default='datasets/duplicates/train', type=str, help='重复图片输出目录')
+    parser.add_argument('--distance_threshold', default=4, type=int, help='感知哈希汉明距离阈值，默认 4')
+    parser.add_argument('--hash_size', default=8, type=int, help='dHash 尺寸，默认 8 生成 64 位哈希')
+    parser.add_argument('--clear_duplicates', action='store_true', help='运行前清空重复图片输出目录')
+    return parser.parse_args()
+
+
+def iter_image_files(folder_path):
+    for filename in sorted(os.listdir(folder_path)):
+        if filename.lower().endswith(IMAGE_EXTENSIONS):
+            yield filename
+
+
+def hamming_distance(left, right):
+    return (left ^ right).bit_count()
+
+
+def compute_dhash(image_path, hash_size):
+    with Image.open(image_path) as image:
+        grayscale = image.convert('L')
+        resized = grayscale.resize((hash_size + 1, hash_size), RESAMPLE)
+        pixels = list(resized.getdata())
+
+    hash_value = 0
+    row_width = hash_size + 1
+    for row in range(hash_size):
+        offset = row * row_width
+        for col in range(hash_size):
+            left = pixels[offset + col]
+            right = pixels[offset + col + 1]
+            hash_value = (hash_value << 1) | int(left > right)
+    return hash_value
+
+
+def collect_samples(input_dir, class_names):
+    samples_by_class = {class_name: [] for class_name in class_names}
+    skipped_folders = []
+
+    for folder_name in sorted(os.listdir(input_dir)):
+        folder_path = os.path.join(input_dir, folder_name)
+        if not os.path.isdir(folder_path):
+            continue
+
+        canonical_name, is_hard_case = resolve_canonical_class_name(folder_name, class_names)
+        if canonical_name is None:
+            skipped_folders.append(folder_name)
+            continue
+
+        for filename in iter_image_files(folder_path):
+            samples_by_class[canonical_name].append({
+                'canonical_name': canonical_name,
+                'source_folder': folder_name,
+                'source_path': os.path.join(folder_path, filename),
+                'filename': filename,
+                'is_hard_case': is_hard_case,
+            })
+
+    return samples_by_class, skipped_folders
+
+
+def ensure_duplicates_dir(duplicates_dir, clear_duplicates):
+    if clear_duplicates and os.path.isdir(duplicates_dir):
+        shutil.rmtree(duplicates_dir)
+    os.makedirs(duplicates_dir, exist_ok=True)
+
+
+def build_duplicate_path(duplicates_dir, sample):
+    target_dir = os.path.join(duplicates_dir, sample['source_folder'])
+    os.makedirs(target_dir, exist_ok=True)
+
+    stem, ext = os.path.splitext(sample['filename'])
+    candidate_path = os.path.join(target_dir, sample['filename'])
+    suffix = 1
+    while os.path.exists(candidate_path):
+        candidate_path = os.path.join(target_dir, f'{stem}_{suffix}{ext}')
+        suffix += 1
+    return candidate_path
+
+
+def sample_priority(sample):
+    return (0 if sample['is_hard_case'] else 1, sample['source_folder'], sample['filename'])
+
+
+def deduplicate_dataset(input_dir, duplicates_dir, distance_threshold, hash_size, clear_duplicates):
+    if not os.path.isdir(input_dir):
+        raise FileNotFoundError(f'输入目录不存在: {input_dir}')
+    if distance_threshold < 0:
+        raise ValueError(f'distance_threshold 不能小于 0，当前为 {distance_threshold}')
+    if hash_size < 4:
+        raise ValueError(f'hash_size 不能小于 4，当前为 {hash_size}')
+
+    ensure_duplicates_dir(duplicates_dir, clear_duplicates)
+    class_names = list(DEFAULT_CLASS_NAMES)
+    samples_by_class, skipped_folders = collect_samples(input_dir, class_names)
+
+    summary = []
+    total_kept = 0
+    total_duplicates = 0
+    invalid_images = []
+    report_rows = []
+
+    for class_name in class_names:
+        tree = BKTree()
+        kept_count = 0
+        duplicate_count = 0
+        samples = sorted(samples_by_class[class_name], key=sample_priority)
+
+        for sample in samples:
+            try:
+                hash_value = compute_dhash(sample['source_path'], hash_size)
+            except (OSError, UnidentifiedImageError) as exc:
+                invalid_images.append((sample['source_path'], str(exc)))
+                continue
+
+            matched_node, distance = tree.query(hash_value, distance_threshold)
+            if matched_node is None:
+                tree.add(hash_value, sample)
+                kept_count += 1
+                continue
+
+            duplicate_path = build_duplicate_path(duplicates_dir, sample)
+            shutil.move(sample['source_path'], duplicate_path)
+            duplicate_count += 1
+            report_rows.append(
+                f"{sample['source_path']}\t{duplicate_path}\t{matched_node.sample['source_path']}\t{distance}"
+            )
+
+        total_kept += kept_count
+        total_duplicates += duplicate_count
+        summary.append({
+            'class_name': class_name,
+            'source_total': len(samples),
+            'kept_count': kept_count,
+            'duplicate_count': duplicate_count,
+        })
+
+    report_path = os.path.join(duplicates_dir, 'dedup_report.tsv')
+    with open(report_path, 'w', encoding='utf-8') as report_file:
+        report_file.write('source_path\tduplicate_path\tkept_reference\thamming_distance\n')
+        for row in report_rows:
+            report_file.write(f'{row}\n')
+
+    invalid_report_path = None
+    if invalid_images:
+        invalid_report_path = os.path.join(duplicates_dir, 'invalid_images.txt')
+        with open(invalid_report_path, 'w', encoding='utf-8') as invalid_file:
+            for path, error_message in invalid_images:
+                invalid_file.write(f'{path}\t{error_message}\n')
+
+    return {
+        'summary': summary,
+        'skipped_folders': skipped_folders,
+        'total_kept': total_kept,
+        'total_duplicates': total_duplicates,
+        'report_path': report_path,
+        'invalid_report_path': invalid_report_path,
+    }
+
+
+def main():
+    args = parse_args()
+    result = deduplicate_dataset(
+        input_dir=args.input_dir,
+        duplicates_dir=args.duplicates_dir,
+        distance_threshold=args.distance_threshold,
+        hash_size=args.hash_size,
+        clear_duplicates=args.clear_duplicates,
+    )
+
+    print(
+        f"完成去重 | 输入目录: {args.input_dir} | 重复图目录: {args.duplicates_dir} | "
+        f"阈值: {args.distance_threshold} | 保留: {result['total_kept']} | 去重: {result['total_duplicates']}"
+    )
+    for item in result['summary']:
+        print(
+            f"类别 {item['class_name']} | 原始样本数: {item['source_total']} | "
+            f"保留: {item['kept_count']} | 去重移出: {item['duplicate_count']}"
+        )
+
+    if result['skipped_folders']:
+        print(f"已跳过未识别目录: {result['skipped_folders']}")
+
+    print(f"去重报告: {result['report_path']}")
+    if result['invalid_report_path']:
+        print(f"异常图片报告: {result['invalid_report_path']}")
+
+
+if __name__ == '__main__':
+    main()

--- a/combat/skill_ready/export.md
+++ b/combat/skill_ready/export.md
@@ -1,0 +1,32 @@
+# ONNX 导出说明
+
+## 默认行为
+
+运行下面的命令时：
+
+```bash
+python export.py --config configs/mobilenetv4_conv_small.yaml
+```
+
+导出脚本会自动执行以下步骤：
+
+1. 读取配置文件。
+2. 创建模型结构。
+3. 默认加载 `checkpoints/{model_name}/skill_ready_cls.pth`。
+4. 将当前权重导出为 `onnx/{model_name}/skill_ready_cls.onnx`。
+
+这意味着如果你已经训练并生成了最佳检查点，直接运行上面的命令就会导出带权重的 ONNX 模型，不需要手动再改代码。
+
+## 显式指定权重
+
+如果你想导出其他 `.pth` 文件，可以显式传入：
+
+```bash
+python export.py --config configs/mobilenetv4_conv_small.yaml --weights checkpoints/mobilenetv4_conv_small/skill_ready_cls.pth
+```
+
+## 注意事项
+
+- 导出前必须加载 `.pth` 权重，否则导出的 ONNX 只有初始化参数。
+- 如果默认检查点不存在，脚本会直接报错，不会导出空模型。
+- 导出使用的是 CPU 设备，不影响最终 ONNX 的推理使用方式。

--- a/combat/skill_ready/export.py
+++ b/combat/skill_ready/export.py
@@ -5,10 +5,12 @@ import torch
 from core.model_builder import create_model
 from utils.path_manager import get_model_paths
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description='Export model to ONNX format')
     parser.add_argument('--config', help='指定模型配置文件',
                         default='configs/mobilenetv4_conv_small.yaml', type=str)
+    parser.add_argument('--weights', help='指定导出时加载的 pth 权重路径；默认使用最佳检查点', type=str)
     args = parser.parse_args()
     return args
 
@@ -33,7 +35,7 @@ def main():
     # 4. 初始化模型
     try:
         model = create_model(config).to(device)
-        checkpoint_path = paths['checkpoint_export']
+        checkpoint_path = args.weights or paths['checkpoint_export']
         
         if not os.path.exists(checkpoint_path):
             raise FileNotFoundError(f"检查点文件 {checkpoint_path} 不存在")
@@ -41,7 +43,7 @@ def main():
         model.load_state_dict(torch.load(checkpoint_path, map_location=device))
         model.eval()
         print(f"已加载最佳模型权重: {checkpoint_path}")
-    except RuntimeError as e:
+    except (RuntimeError, FileNotFoundError) as e:
         print(f"模型加载失败: {str(e)}")
         return
 

--- a/combat/skill_ready/onnx_inference.py
+++ b/combat/skill_ready/onnx_inference.py
@@ -1,10 +1,11 @@
 import os
+import shutil
 import yaml
 import torch
 import time
 import numpy as np
 import argparse
-from core.data_loader import SkillIconDataset
+from core.data_loader import SkillIconDataset, get_dataset_class_counts, get_dataset_class_weights
 from core.model_builder import create_model
 from utils.logger import MetricLogger
 from torch.utils.data import DataLoader
@@ -13,12 +14,29 @@ import onnxruntime as ort
 from torchvision.utils import save_image
 from utils.img_process import unnormalize
 
+
+def build_hard_example_path(hard_example_root, true_class_name, pred_class_name, image_path):
+    target_dir = os.path.join(hard_example_root, f"{true_class_name}_err")
+    os.makedirs(target_dir, exist_ok=True)
+
+    stem, ext = os.path.splitext(os.path.basename(image_path))
+    base_name = f"{stem}__pred_{pred_class_name}"
+    candidate_path = os.path.join(target_dir, f"{base_name}{ext}")
+    suffix = 1
+
+    while os.path.exists(candidate_path):
+        candidate_path = os.path.join(target_dir, f"{base_name}_{suffix}{ext}")
+        suffix += 1
+
+    return candidate_path
+
 def parse_args():
     parser = argparse.ArgumentParser(description='Validate ONNX format model weights')
     parser.add_argument('--config', help='指定模型配置文件',
                         default='configs/mobilenetv4_conv_small.yaml', type=str, required=True)
     parser.add_argument('--weights', help='指定onnx路径', type=str)
     parser.add_argument('--val_path', help='指定验证集路径', default='datasets/val', type=str)
+    parser.add_argument('--hard_example_dir', help='将误判图片按真实类别导出到训练目录，如 datasets/train', type=str)
     args = parser.parse_args()
     return args
 
@@ -57,7 +75,17 @@ def main():
             num_workers=4,
             pin_memory=True
         )
+        val_class_counts = get_dataset_class_counts(val_dataset, len(model_wrapper.class_names))
+        val_class_weights = get_dataset_class_weights(val_dataset, len(model_wrapper.class_names))
         print(f"数据加载器统计 | 指定验证集路径: {args.val_path} | 验证集样本: {len(val_loader.dataset)} | 批次: {len(val_loader)}")
+        print(
+            f"验证集类别计数 | "
+            f"{' | '.join(f'{name}: {int(count)}' for name, count in zip(model_wrapper.class_names, val_class_counts.tolist()))}"
+        )
+        print(
+            f"验证集评估权重 | "
+            f"{' | '.join(f'{name}: {weight:.4f}' for name, weight in zip(model_wrapper.class_names, val_class_weights.tolist()))}"
+        )
     except KeyError as e:
         print(f"数据加载配置错误: {str(e)}")
         return
@@ -80,7 +108,7 @@ def main():
         log_dir=os.path.join("onnx_val"),
         class_names=['c', 'n', 'y'],
         model_name=config['model']['name'],
-        class_weights=None
+        class_weights=val_class_weights
     )
 
     # 6. 推理性能测试
@@ -126,6 +154,7 @@ def main():
     print("\n开始完整验证...")
     logger.new_epoch()
     total_samples = 0
+    hard_example_count = 0
 
     # 创建保存错误图片的 debug 目录
     debug_base_dir = os.path.join("debug", f"debug_{config['model']['name']}_{time.strftime('%Y%m%d_%H%M%S')}")
@@ -179,7 +208,19 @@ def main():
                             save_image(unnormalize(images[i].cpu(), device), save_path)
                             print(f"保存错误分类图片: {save_path}")
 
+                            if args.hard_example_dir:
+                                target_path = build_hard_example_path(
+                                    args.hard_example_dir,
+                                    logger.class_names[true_class],
+                                    logger.class_names[pred_class],
+                                    image_path
+                                )
+                                shutil.copy2(image_path, target_path)
+                                hard_example_count += 1
+
         print(f"已验证样本总数: {total_samples}")
+        if args.hard_example_dir:
+            print(f"已导出难例样本数: {hard_example_count} -> {args.hard_example_dir}")
     except RuntimeError as e:
         print(f"验证过程异常: {str(e)}")
         return

--- a/combat/skill_ready/onnx_inference.py
+++ b/combat/skill_ready/onnx_inference.py
@@ -5,7 +5,7 @@ import torch
 import time
 import numpy as np
 import argparse
-from core.data_loader import SkillIconDataset, get_dataset_class_counts, get_dataset_class_weights
+from core.data_loader import SkillIconDataset, get_dataset_class_counts, get_dataset_class_weights, get_dataset_sample_weights
 from core.model_builder import create_model
 from utils.logger import MetricLogger
 from torch.utils.data import DataLoader
@@ -75,8 +75,14 @@ def main():
             num_workers=4,
             pin_memory=True
         )
+        err_folder_weight = float(config['training'].get('sampler', {}).get('err_folder_weight', 1.0))
         val_class_counts = get_dataset_class_counts(val_dataset, len(model_wrapper.class_names))
         val_class_weights = get_dataset_class_weights(val_dataset, len(model_wrapper.class_names))
+        val_sample_weights = get_dataset_sample_weights(
+            val_dataset,
+            len(model_wrapper.class_names),
+            err_folder_weight=err_folder_weight
+        )
         print(f"数据加载器统计 | 指定验证集路径: {args.val_path} | 验证集样本: {len(val_loader.dataset)} | 批次: {len(val_loader)}")
         print(
             f"验证集类别计数 | "
@@ -86,6 +92,7 @@ def main():
             f"验证集评估权重 | "
             f"{' | '.join(f'{name}: {weight:.4f}' for name, weight in zip(model_wrapper.class_names, val_class_weights.tolist()))}"
         )
+        print(f"验证集难例加权系数 | _err: {err_folder_weight:.2f}")
     except KeyError as e:
         print(f"数据加载配置错误: {str(e)}")
         return
@@ -108,8 +115,10 @@ def main():
         log_dir=os.path.join("onnx_val"),
         class_names=['c', 'n', 'y'],
         model_name=config['model']['name'],
-        class_weights=val_class_weights
+        class_weights=val_class_weights,
+        val_sample_weights=val_sample_weights
     )
+    print(f"验证报告目录: {logger.log_dir}")
 
     # 6. 推理性能测试
     try:
@@ -235,6 +244,11 @@ def main():
         print(f"\n验证结果 | 准确率: {logger.val_metrics['accuracy']:.2%}")
     else:
         print("未计算验证指标，请检查数据记录")
+    report_paths = logger.get_report_paths()
+    print(f"分类报告: {report_paths['classification_report']}")
+    print(f"混淆矩阵: {report_paths['confusion_matrix']}")
+    print(f"分类指标图: {report_paths['classification_metrics']}")
+    logger.writer.close()
 
 if __name__ == "__main__":
     main()

--- a/combat/skill_ready/onnx_inference.py
+++ b/combat/skill_ready/onnx_inference.py
@@ -75,13 +75,11 @@ def main():
             num_workers=4,
             pin_memory=True
         )
-        err_folder_weight = float(config['training'].get('sampler', {}).get('err_folder_weight', 1.0))
         val_class_counts = get_dataset_class_counts(val_dataset, len(model_wrapper.class_names))
         val_class_weights = get_dataset_class_weights(val_dataset, len(model_wrapper.class_names))
         val_sample_weights = get_dataset_sample_weights(
             val_dataset,
-            len(model_wrapper.class_names),
-            err_folder_weight=err_folder_weight
+            len(model_wrapper.class_names)
         )
         print(f"数据加载器统计 | 指定验证集路径: {args.val_path} | 验证集样本: {len(val_loader.dataset)} | 批次: {len(val_loader)}")
         print(
@@ -92,7 +90,7 @@ def main():
             f"验证集评估权重 | "
             f"{' | '.join(f'{name}: {weight:.4f}' for name, weight in zip(model_wrapper.class_names, val_class_weights.tolist()))}"
         )
-        print(f"验证集难例加权系数 | _err: {err_folder_weight:.2f}")
+        print("验证集评估策略 | 仅按类别数量加权，不对 _err 额外加权")
     except KeyError as e:
         print(f"数据加载配置错误: {str(e)}")
         return

--- a/combat/skill_ready/split_dataset.py
+++ b/combat/skill_ready/split_dataset.py
@@ -1,0 +1,161 @@
+import argparse
+import os
+import random
+import shutil
+
+from core.data_loader import DEFAULT_CLASS_NAMES, resolve_canonical_class_name
+
+
+IMAGE_EXTENSIONS = ('.png', '.jpg', '.jpeg')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Split part of training set into validation set')
+    parser.add_argument('--train_dir', default='datasets/train', type=str, help='训练集目录，支持 c/n/y 和 *_err')
+    parser.add_argument('--val_dir', default='datasets/val', type=str, help='验证集目录，只会写入 c/n/y')
+    parser.add_argument('--val_ratio', default=0.1, type=float, help='验证集占比，默认 0.1')
+    parser.add_argument('--seed', default=42, type=int, help='随机种子')
+    parser.add_argument('--move', action='store_true', help='移动文件到验证集；默认是复制')
+    parser.add_argument('--clear_val', action='store_true', help='划分前清空验证集目录')
+    return parser.parse_args()
+
+
+def iter_image_files(folder_path):
+    for filename in sorted(os.listdir(folder_path)):
+        if filename.lower().endswith(IMAGE_EXTENSIONS):
+            yield filename
+
+
+def collect_samples(train_dir, class_names):
+    samples_by_class = {class_name: [] for class_name in class_names}
+    skipped_folders = []
+
+    for folder_name in sorted(os.listdir(train_dir)):
+        folder_path = os.path.join(train_dir, folder_name)
+        if not os.path.isdir(folder_path):
+            continue
+
+        canonical_name, is_hard_case = resolve_canonical_class_name(folder_name, class_names)
+        if canonical_name is None:
+            skipped_folders.append(folder_name)
+            continue
+
+        for filename in iter_image_files(folder_path):
+            samples_by_class[canonical_name].append({
+                'source_folder': folder_name,
+                'source_path': os.path.join(folder_path, filename),
+                'filename': filename,
+                'is_hard_case': is_hard_case,
+            })
+
+    return samples_by_class, skipped_folders
+
+
+def ensure_empty_or_create_val_dir(val_dir, class_names, clear_val):
+    if clear_val and os.path.isdir(val_dir):
+        shutil.rmtree(val_dir)
+
+    os.makedirs(val_dir, exist_ok=True)
+    existing_files = []
+    for class_name in class_names:
+        class_dir = os.path.join(val_dir, class_name)
+        os.makedirs(class_dir, exist_ok=True)
+        existing_files.extend(list(iter_image_files(class_dir)))
+
+    if existing_files and not clear_val:
+        raise FileExistsError(
+            f'验证集目录 {val_dir} 已存在图片，请先清空，或使用 --clear_val 重新划分。'
+        )
+
+
+def build_destination_path(val_dir, class_name, source_folder, filename):
+    target_dir = os.path.join(val_dir, class_name)
+    stem, ext = os.path.splitext(filename)
+    candidate_path = os.path.join(target_dir, filename)
+
+    if source_folder.endswith('_err'):
+        candidate_path = os.path.join(target_dir, f'{stem}__from_{source_folder}{ext}')
+
+    suffix = 1
+    while os.path.exists(candidate_path):
+        base_name = f'{stem}__from_{source_folder}_{suffix}{ext}'
+        candidate_path = os.path.join(target_dir, base_name)
+        suffix += 1
+
+    return candidate_path
+
+
+def split_dataset(train_dir, val_dir, val_ratio, seed, copy_files, clear_val):
+    if not os.path.isdir(train_dir):
+        raise FileNotFoundError(f'训练集目录不存在: {train_dir}')
+
+    if not 0 < val_ratio < 1:
+        raise ValueError(f'val_ratio 必须在 0 和 1 之间，当前为 {val_ratio}')
+
+    class_names = list(DEFAULT_CLASS_NAMES)
+    ensure_empty_or_create_val_dir(val_dir, class_names, clear_val)
+
+    samples_by_class, skipped_folders = collect_samples(train_dir, class_names)
+    rng = random.Random(seed)
+
+    summary = []
+    total_selected = 0
+    for class_name in class_names:
+        samples = samples_by_class[class_name]
+        rng.shuffle(samples)
+        selected_count = int(len(samples) * val_ratio)
+        selected_samples = samples[:selected_count]
+
+        hard_case_count = 0
+        for sample in selected_samples:
+            destination_path = build_destination_path(
+                val_dir,
+                class_name,
+                sample['source_folder'],
+                sample['filename']
+            )
+            if copy_files:
+                shutil.copy2(sample['source_path'], destination_path)
+            else:
+                shutil.move(sample['source_path'], destination_path)
+
+            if sample['is_hard_case']:
+                hard_case_count += 1
+
+        total_selected += selected_count
+        summary.append({
+            'class_name': class_name,
+            'source_total': len(samples),
+            'selected_count': selected_count,
+            'hard_case_count': hard_case_count,
+        })
+
+    return summary, skipped_folders, total_selected
+
+
+def main():
+    args = parse_args()
+
+    summary, skipped_folders, total_selected = split_dataset(
+        train_dir=args.train_dir,
+        val_dir=args.val_dir,
+        val_ratio=args.val_ratio,
+        seed=args.seed,
+        copy_files=not args.move,
+        clear_val=args.clear_val,
+    )
+
+    operation = '移动' if args.move else '复制'
+    print(f'完成数据集划分 | 操作: {operation} | 验证集占比: {args.val_ratio:.2%} | 总转移样本数: {total_selected}')
+    for item in summary:
+        print(
+            f"类别 {item['class_name']} | 原始样本数: {item['source_total']} | "
+            f"划入验证集: {item['selected_count']} | 其中来自 *_err: {item['hard_case_count']}"
+        )
+
+    if skipped_folders:
+        print(f'已跳过未识别目录: {skipped_folders}')
+
+
+if __name__ == '__main__':
+    main()

--- a/combat/skill_ready/train.py
+++ b/combat/skill_ready/train.py
@@ -178,13 +178,11 @@ def main():
             train_transform=model_wrapper.train_transform,
             val_transform=model_wrapper.val_transform
         )
-        err_folder_weight = float(config['training'].get('sampler', {}).get('err_folder_weight', 1.0))
         val_class_counts = get_dataset_class_counts(val_loader.dataset, len(model_wrapper.class_names))
         val_class_weights = get_dataset_class_weights(val_loader.dataset, len(model_wrapper.class_names))
         val_sample_weights = get_dataset_sample_weights(
             val_loader.dataset,
-            len(model_wrapper.class_names),
-            err_folder_weight=err_folder_weight
+            len(model_wrapper.class_names)
         )
         print(
             f"数据加载器创建完成 | 训练样本数: {len(train_loader.dataset)} | 验证样本数: {len(val_loader.dataset)} | "
@@ -192,7 +190,7 @@ def main():
         )
         print(f"验证集类别计数 | {format_class_stats(model_wrapper.class_names, val_class_counts.tolist())}")
         print(f"验证集评估权重 | {format_class_stats(model_wrapper.class_names, val_class_weights.tolist(), precision=4)}")
-        print(f"验证集难例加权系数 | _err: {err_folder_weight:.2f}")
+        print("验证集评估策略 | 仅按类别数量加权，不对 _err 额外加权")
     except KeyError as e:
         print(f"数据加载配置错误: {str(e)}")
         return

--- a/combat/skill_ready/train.py
+++ b/combat/skill_ready/train.py
@@ -8,7 +8,7 @@ import argparse
 from torch import nn
 
 from utils.loss import CostSensitiveCrossEntropyLoss, FocalLoss
-from core.data_loader import create_loaders, get_dataset_class_counts, get_dataset_class_weights
+from core.data_loader import create_loaders, get_dataset_class_counts, get_dataset_class_weights, get_dataset_sample_weights
 from core.model_builder import create_model
 from utils.logger import MetricLogger
 from torch.amp import autocast, GradScaler
@@ -102,7 +102,7 @@ def format_class_stats(class_names, values, precision=None):
     return ' | '.join(parts)
 
 
-def evaluate_accuracy(model, data_loader, device, use_cuda_amp=False, class_weights=None):
+def evaluate_accuracy(model, data_loader, device, use_cuda_amp=False, sample_weights=None):
     was_training = model.training
     model.eval()
     total_correct = 0
@@ -122,7 +122,7 @@ def evaluate_accuracy(model, data_loader, device, use_cuda_amp=False, class_weig
             predictions = outputs.argmax(dim=1)
             total_correct += (predictions == labels).sum().item()
             total_samples += labels.size(0)
-            if class_weights is not None:
+            if sample_weights is not None:
                 predictions_list.append(predictions.detach().cpu())
                 labels_list.append(labels.detach().cpu())
 
@@ -131,10 +131,10 @@ def evaluate_accuracy(model, data_loader, device, use_cuda_amp=False, class_weig
 
     if total_samples == 0:
         return 0.0
-    if class_weights is not None:
+    if sample_weights is not None:
         predictions = torch.cat(predictions_list)
         labels = torch.cat(labels_list)
-        weights = class_weights.detach().cpu()[labels]
+        weights = sample_weights.detach().cpu()
         weighted_correct = weights * (predictions == labels).float()
         return (weighted_correct.sum() / weights.sum().clamp_min(1e-12)).item()
     return total_correct / total_samples
@@ -178,14 +178,21 @@ def main():
             train_transform=model_wrapper.train_transform,
             val_transform=model_wrapper.val_transform
         )
+        err_folder_weight = float(config['training'].get('sampler', {}).get('err_folder_weight', 1.0))
         val_class_counts = get_dataset_class_counts(val_loader.dataset, len(model_wrapper.class_names))
         val_class_weights = get_dataset_class_weights(val_loader.dataset, len(model_wrapper.class_names))
+        val_sample_weights = get_dataset_sample_weights(
+            val_loader.dataset,
+            len(model_wrapper.class_names),
+            err_folder_weight=err_folder_weight
+        )
         print(
             f"数据加载器创建完成 | 训练样本数: {len(train_loader.dataset)} | 验证样本数: {len(val_loader.dataset)} | "
             f"训练采样器: {type(train_loader.sampler).__name__}"
         )
         print(f"验证集类别计数 | {format_class_stats(model_wrapper.class_names, val_class_counts.tolist())}")
         print(f"验证集评估权重 | {format_class_stats(model_wrapper.class_names, val_class_weights.tolist(), precision=4)}")
+        print(f"验证集难例加权系数 | _err: {err_folder_weight:.2f}")
     except KeyError as e:
         print(f"数据加载配置错误: {str(e)}")
         return
@@ -288,13 +295,15 @@ def main():
         log_dir="train",  # Specify log directory
         class_names=['c', 'n', 'y'],  # Specify class names
         model_name=config['model']['name'], # Specify model name
-        class_weights=val_class_weights
+        class_weights=val_class_weights,
+        val_sample_weights=val_sample_weights
     )
+    print(f"训练报告目录: {logger.log_dir}")
 
     # 9. 训练
     best_acc = 0.0
     if args.weights:
-        best_acc = evaluate_accuracy(model, val_loader, device, use_cuda_amp, val_class_weights)
+        best_acc = evaluate_accuracy(model, val_loader, device, use_cuda_amp, val_sample_weights)
         print(f"微调起点验证集准确率: {best_acc:.4f}")
 
     for epoch in range(config['training']['epochs']):
@@ -375,6 +384,13 @@ def main():
                 early_stopping_state['epochs_without_improvement'] >= early_stopping_state['patience']:
             print(f"触发 Early stopping | 停止于 epoch {epoch+1} | 最佳验证集准确率: {best_acc:.4f}")
             break
+
+    report_paths = logger.get_report_paths()
+    print(f"分类报告: {report_paths['classification_report']}")
+    print(f"混淆矩阵: {report_paths['confusion_matrix']}")
+    print(f"分类指标图: {report_paths['classification_metrics']}")
+    print(f"训练曲线图: {report_paths['training_curves']}")
+    logger.writer.close()
 
 if __name__ == "__main__":
     main()

--- a/combat/skill_ready/train.py
+++ b/combat/skill_ready/train.py
@@ -6,17 +6,90 @@ import argparse
 
 from torch import nn
 
-from utils.loss import FocalLoss
-from core.data_loader import create_loaders
+from utils.loss import CostSensitiveCrossEntropyLoss, FocalLoss
+from core.data_loader import create_loaders, get_dataset_class_counts, get_dataset_class_weights
 from core.model_builder import create_model
 from utils.logger import MetricLogger
 from torch.amp import autocast, GradScaler
 from utils.path_manager import get_model_paths
 
+
+def build_confusion_cost(class_names, loss_config):
+    penalty_config = loss_config.get('confusion_penalty', {})
+    if not penalty_config.get('enabled', False):
+        return None, 0.0
+
+    class_to_idx = {name: index for index, name in enumerate(class_names)}
+    confusion_cost = torch.zeros(len(class_names), len(class_names), dtype=torch.float32)
+
+    c_index = class_to_idx.get('c')
+    y_index = class_to_idx.get('y')
+    if c_index is not None and y_index is not None:
+        confusion_cost[c_index, y_index] = float(penalty_config.get('c_to_y', 0.0))
+
+    return confusion_cost, float(penalty_config.get('weight', 0.0))
+
+
+def build_loss_class_weights(model, loss_config, device):
+    class_weight_config = loss_config.get('class_weight', {})
+    if not class_weight_config.get('enabled', True):
+        return None
+
+    return model.class_weights.to(device)
+
+
+def format_class_stats(class_names, values, precision=None):
+    parts = []
+    for name, value in zip(class_names, values):
+        if precision is None:
+            parts.append(f"{name}: {int(value)}")
+        else:
+            parts.append(f"{name}: {value:.{precision}f}")
+    return ' | '.join(parts)
+
+
+def evaluate_accuracy(model, data_loader, device, use_cuda_amp=False, class_weights=None):
+    was_training = model.training
+    model.eval()
+    total_correct = 0
+    total_samples = 0
+    predictions_list = []
+    labels_list = []
+
+    with torch.no_grad():
+        for images, labels in data_loader:
+            images, labels = images.to(device), labels.to(device)
+            if use_cuda_amp and device.type == 'cuda':
+                with autocast('cuda'):
+                    outputs = model(images)
+            else:
+                outputs = model(images)
+
+            predictions = outputs.argmax(dim=1)
+            total_correct += (predictions == labels).sum().item()
+            total_samples += labels.size(0)
+            if class_weights is not None:
+                predictions_list.append(predictions.detach().cpu())
+                labels_list.append(labels.detach().cpu())
+
+    if was_training:
+        model.train()
+
+    if total_samples == 0:
+        return 0.0
+    if class_weights is not None:
+        predictions = torch.cat(predictions_list)
+        labels = torch.cat(labels_list)
+        weights = class_weights.detach().cpu()[labels]
+        weighted_correct = weights * (predictions == labels).float()
+        return (weighted_correct.sum() / weights.sum().clamp_min(1e-12)).item()
+    return total_correct / total_samples
+
 def parse_args():
     parser = argparse.ArgumentParser(description='Train model scripts')
     parser.add_argument('--config', help='Specify model configuration file',
                         default='configs/mobilenetv4_conv_small.yaml', type=str, required=True)
+    parser.add_argument('--weights', help='Specify pth path for fine-tuning start point', type=str)
     args = parser.parse_args()
     return args
 
@@ -33,6 +106,10 @@ def main():
         print(f"错误：配置文件 {args.config} 不存在")
         return
 
+    if args.weights:
+        config['model']['pretrained'] = False
+        print(f"微调模式 | 起始权重: {args.weights}")
+
     # 2. 初始化训练设备
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"使用设备: {device}")
@@ -47,14 +124,26 @@ def main():
             train_transform=model_wrapper.train_transform,
             val_transform=model_wrapper.val_transform
         )
-        print("数据加载器创建完成")
+        val_class_counts = get_dataset_class_counts(val_loader.dataset, len(model_wrapper.class_names))
+        val_class_weights = get_dataset_class_weights(val_loader.dataset, len(model_wrapper.class_names))
+        print(
+            f"数据加载器创建完成 | 训练样本数: {len(train_loader.dataset)} | 验证样本数: {len(val_loader.dataset)} | "
+            f"训练采样器: {type(train_loader.sampler).__name__}"
+        )
+        print(f"验证集类别计数 | {format_class_stats(model_wrapper.class_names, val_class_counts.tolist())}")
+        print(f"验证集评估权重 | {format_class_stats(model_wrapper.class_names, val_class_weights.tolist(), precision=4)}")
     except KeyError as e:
         print(f"数据加载配置错误: {str(e)}")
         return
     
     # 4. 初始化模型
     try:
-        model = create_model(config).to(device)
+        model = model_wrapper.to(device)
+        if args.weights:
+            if not os.path.exists(args.weights):
+                raise FileNotFoundError(f"微调权重文件 {args.weights} 不存在")
+            model.load_state_dict(torch.load(args.weights, map_location=device))
+            print(f"已加载微调起点权重: {args.weights}")
         print("模型初始化成功")
     except Exception as e:
         print(f"模型初始化失败: {str(e)}")
@@ -80,12 +169,37 @@ def main():
         return
 
     # 6. 初始化损失函数
-    loss_type = config['training']['loss']['type']
+    loss_config = config['training']['loss']
+    loss_type = loss_config['type']
+    confusion_cost, confusion_weight = build_confusion_cost(model.class_names, loss_config)
+    class_weights = build_loss_class_weights(model, loss_config, device)
+
+    print(f"训练集类别计数 | {format_class_stats(model.class_names, model.class_counts.tolist())}")
+
+    if class_weights is not None:
+        print(
+            f"启用自动类别权重 | "
+            f"{format_class_stats(model.class_names, class_weights.detach().cpu().tolist(), precision=4)}"
+        )
+    else:
+        print("未启用自动类别权重")
+
+    if confusion_cost is not None and confusion_weight > 0:
+        print(f"启用非对称误判惩罚 | c->y 额外权重: {confusion_cost[0, 2].item():.2f} | 损失系数: {confusion_weight:.2f}")
+
     # 如果特指使用FocalLoss，其余情况一律使用CrossEntropyLoss
     if loss_type == 'focal':
-        criterion = FocalLoss().to(device)
+        criterion = FocalLoss(
+            weight=class_weights,
+            confusion_cost=confusion_cost,
+            confusion_weight=confusion_weight
+        ).to(device)
     else:
-        criterion = nn.CrossEntropyLoss(weight=None).to(device)
+        criterion = CostSensitiveCrossEntropyLoss(
+            weight=class_weights,
+            confusion_cost=confusion_cost,
+            confusion_weight=confusion_weight
+        ).to(device)
 
     # 7. 混合精度训练
     try:
@@ -102,11 +216,15 @@ def main():
         log_dir="train",  # Specify log directory
         class_names=['c', 'n', 'y'],  # Specify class names
         model_name=config['model']['name'], # Specify model name
-        class_weights=None # class_weights.cpu().numpy() if torch.cuda.is_available() else class_weights.numpy()
+        class_weights=val_class_weights
     )
 
     # 9. 训练
     best_acc = 0.0
+    if args.weights:
+        best_acc = evaluate_accuracy(model, val_loader, device, use_cuda_amp, val_class_weights)
+        print(f"微调起点验证集准确率: {best_acc:.4f}")
+
     for epoch in range(config['training']['epochs']):
         print()
         print(f"Epoch {epoch+1} 开始")

--- a/combat/skill_ready/train.py
+++ b/combat/skill_ready/train.py
@@ -1,4 +1,5 @@
 import os
+import math
 import yaml
 import torch
 import torch.optim as optim
@@ -36,6 +37,59 @@ def build_loss_class_weights(model, loss_config, device):
         return None
 
     return model.class_weights.to(device)
+
+
+def build_lr_scheduler_state(config, optimizer):
+    scheduler_config = config['training'].get('lr_scheduler', {})
+    scheduler_type = scheduler_config.get('type')
+    if not scheduler_type:
+        return None
+
+    scheduler_type = scheduler_type.lower()
+    if scheduler_type != 'cosine':
+        raise ValueError(f"不支持的学习率调度类型: {scheduler_type}")
+
+    return {
+        'type': scheduler_type,
+        'epochs': int(config['training']['epochs']),
+        'warmup_epochs': max(0, int(scheduler_config.get('warmup_epochs', 0))),
+        'min_lr': float(scheduler_config.get('min_lr', 0.0)),
+        'base_lrs': [group['lr'] for group in optimizer.param_groups],
+    }
+
+
+def apply_epoch_learning_rate(epoch, optimizer, scheduler_state):
+    if scheduler_state is None:
+        return optimizer.param_groups[0]['lr']
+
+    total_epochs = max(1, scheduler_state['epochs'])
+    warmup_epochs = min(scheduler_state['warmup_epochs'], total_epochs)
+
+    for base_lr, param_group in zip(scheduler_state['base_lrs'], optimizer.param_groups):
+        if warmup_epochs > 0 and epoch < warmup_epochs:
+            lr = base_lr * float(epoch + 1) / warmup_epochs
+        else:
+            cosine_epochs = max(1, total_epochs - warmup_epochs)
+            progress = (epoch - warmup_epochs) / max(1, cosine_epochs - 1)
+            progress = min(max(progress, 0.0), 1.0)
+            min_lr = min(scheduler_state['min_lr'], base_lr)
+            lr = min_lr + (base_lr - min_lr) * 0.5 * (1.0 + math.cos(math.pi * progress))
+
+        param_group['lr'] = lr
+
+    return optimizer.param_groups[0]['lr']
+
+
+def build_early_stopping_state(config):
+    early_stopping_config = config['training'].get('early_stopping', {})
+    if not early_stopping_config.get('enabled', False):
+        return None
+
+    return {
+        'patience': max(1, int(early_stopping_config.get('patience', 5))),
+        'min_delta': float(early_stopping_config.get('min_delta', 0.0)),
+        'epochs_without_improvement': 0,
+    }
 
 
 def format_class_stats(class_names, values, precision=None):
@@ -168,6 +222,24 @@ def main():
         print(f"优化器初始化失败: {str(e)}")
         return
 
+    try:
+        scheduler_state = build_lr_scheduler_state(config, optimizer)
+        if scheduler_state is not None:
+            print(
+                f"启用学习率调度 | 类型: {scheduler_state['type']} | "
+                f"warmup_epochs: {scheduler_state['warmup_epochs']} | min_lr: {scheduler_state['min_lr']:.2e}"
+            )
+    except ValueError as e:
+        print(f"学习率调度配置错误: {str(e)}")
+        return
+
+    early_stopping_state = build_early_stopping_state(config)
+    if early_stopping_state is not None:
+        print(
+            f"启用 Early stopping | patience: {early_stopping_state['patience']} | "
+            f"min_delta: {early_stopping_state['min_delta']:.4f}"
+        )
+
     # 6. 初始化损失函数
     loss_config = config['training']['loss']
     loss_type = loss_config['type']
@@ -227,7 +299,8 @@ def main():
 
     for epoch in range(config['training']['epochs']):
         print()
-        print(f"Epoch {epoch+1} 开始")
+        current_lr = apply_epoch_learning_rate(epoch, optimizer, scheduler_state)
+        print(f"Epoch {epoch+1} 开始 | lr: {current_lr:.2e}")
         # 训练阶段
         model.train()  # 将模型设置为训练模式
         logger.new_epoch()  # 开始新的 epoch
@@ -281,12 +354,27 @@ def main():
 
         # 11. 保存最好的模型
         logger.finalize_epoch()
-        if logger.val_metrics['accuracy'] > best_acc:
-            best_acc = logger.val_metrics['accuracy']
+        current_val_acc = logger.val_metrics['accuracy']
+        if current_val_acc > best_acc + (early_stopping_state['min_delta'] if early_stopping_state else 0.0):
+            best_acc = current_val_acc
             torch.save(model.state_dict(), paths["checkpoint_export"])
+            if early_stopping_state is not None:
+                early_stopping_state['epochs_without_improvement'] = 0
+            print(f"保存最佳模型 | epoch: {epoch+1} | 验证集准确率: {best_acc:.4f}")
+        elif early_stopping_state is not None:
+            early_stopping_state['epochs_without_improvement'] += 1
+            print(
+                f"Early stopping 计数 | {early_stopping_state['epochs_without_improvement']}/"
+                f"{early_stopping_state['patience']} | 当前最佳: {best_acc:.4f}"
+            )
         
         # 生成报告
-        print(f"Epoch {epoch+1} 完成，验证集准确率: {logger.val_metrics['accuracy']:.4f}")
+        print(f"Epoch {epoch+1} 完成，验证集准确率: {current_val_acc:.4f}")
+
+        if early_stopping_state is not None and \
+                early_stopping_state['epochs_without_improvement'] >= early_stopping_state['patience']:
+            print(f"触发 Early stopping | 停止于 epoch {epoch+1} | 最佳验证集准确率: {best_acc:.4f}")
+            break
 
 if __name__ == "__main__":
     main()

--- a/combat/skill_ready/train.py
+++ b/combat/skill_ready/train.py
@@ -18,7 +18,7 @@ from utils.path_manager import get_model_paths
 def build_confusion_cost(class_names, loss_config):
     penalty_config = loss_config.get('confusion_penalty', {})
     if not penalty_config.get('enabled', False):
-        return None, 0.0
+        return None, 0.0, None, None
 
     class_to_idx = {name: index for index, name in enumerate(class_names)}
     confusion_cost = torch.zeros(len(class_names), len(class_names), dtype=torch.float32)
@@ -28,7 +28,7 @@ def build_confusion_cost(class_names, loss_config):
     if c_index is not None and y_index is not None:
         confusion_cost[c_index, y_index] = float(penalty_config.get('c_to_y', 0.0))
 
-    return confusion_cost, float(penalty_config.get('weight', 0.0))
+    return confusion_cost, float(penalty_config.get('weight', 0.0)), c_index, y_index
 
 
 def build_loss_class_weights(model, loss_config, device):
@@ -248,7 +248,7 @@ def main():
     # 6. 初始化损失函数
     loss_config = config['training']['loss']
     loss_type = loss_config['type']
-    confusion_cost, confusion_weight = build_confusion_cost(model.class_names, loss_config)
+    confusion_cost, confusion_weight, c_index, y_index = build_confusion_cost(model.class_names, loss_config)
     class_weights = build_loss_class_weights(model, loss_config, device)
 
     print(f"训练集类别计数 | {format_class_stats(model.class_names, model.class_counts.tolist())}")
@@ -261,8 +261,11 @@ def main():
     else:
         print("未启用自动类别权重")
 
-    if confusion_cost is not None and confusion_weight > 0:
-        print(f"启用非对称误判惩罚 | c->y 额外权重: {confusion_cost[0, 2].item():.2f} | 损失系数: {confusion_weight:.2f}")
+    if confusion_cost is not None and confusion_weight > 0 and c_index is not None and y_index is not None:
+        print(
+            f"启用非对称误判惩罚 | c->y 额外权重: {confusion_cost[c_index, y_index].item():.2f} | "
+            f"损失系数: {confusion_weight:.2f}"
+        )
 
     # 如果特指使用FocalLoss，其余情况一律使用CrossEntropyLoss
     if loss_type == 'focal':

--- a/combat/skill_ready/utils/logger.py
+++ b/combat/skill_ready/utils/logger.py
@@ -12,7 +12,9 @@ class MetricLogger:
         self.class_names = class_names
         self.model_size = None
         self.flops = None
-        self.class_weights = class_weights
+        if class_weights is not None and hasattr(class_weights, 'detach'):
+            class_weights = class_weights.detach().cpu().numpy()
+        self.class_weights = None if class_weights is None else np.asarray(class_weights, dtype=np.float32)
         self.val_metrics = {'loss': [], 'outputs': [], 'labels': [], 'accuracy': 0.0}
         self.epoch = 0  # 添加 epoch 属性
         self.reset()
@@ -40,8 +42,9 @@ class MetricLogger:
         preds = np.argmax(outputs, axis=1)
 
         # 基础指标
-        if self.class_weights is not None:
-            accuracy = np.average(preds == labels, weights=self.class_weights)
+        if phase == 'val' and self.class_weights is not None:
+            sample_weights = self.class_weights[labels.astype(np.int64)]
+            accuracy = np.average(preds == labels, weights=sample_weights)
         else:
             accuracy = np.mean(preds == labels)
         loss = np.mean(self.__dict__[f'{phase}_metrics']['loss'])

--- a/combat/skill_ready/utils/logger.py
+++ b/combat/skill_ready/utils/logger.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from torch.utils.tensorboard import SummaryWriter
 
 class MetricLogger:
-    def __init__(self, log_dir, class_names, model_name, class_weights=None):
+    def __init__(self, log_dir, class_names, model_name, class_weights=None, val_sample_weights=None):
         self.log_dir = os.path.join("logs", log_dir, model_name, time.strftime("%Y%m%d-%H%M%S"))
         self.writer = SummaryWriter(self.log_dir)
         self.class_names = class_names
@@ -14,7 +14,16 @@ class MetricLogger:
         self.flops = None
         if class_weights is not None and hasattr(class_weights, 'detach'):
             class_weights = class_weights.detach().cpu().numpy()
+        if val_sample_weights is not None and hasattr(val_sample_weights, 'detach'):
+            val_sample_weights = val_sample_weights.detach().cpu().numpy()
         self.class_weights = None if class_weights is None else np.asarray(class_weights, dtype=np.float32)
+        self.val_sample_weights = None if val_sample_weights is None else np.asarray(val_sample_weights, dtype=np.float32)
+        self.history = {
+            'train_loss': [],
+            'train_accuracy': [],
+            'val_loss': [],
+            'val_accuracy': []
+        }
         self.val_metrics = {'loss': [], 'outputs': [], 'labels': [], 'accuracy': 0.0}
         self.epoch = 0  # 添加 epoch 属性
         self.reset()
@@ -42,7 +51,9 @@ class MetricLogger:
         preds = np.argmax(outputs, axis=1)
 
         # 基础指标
-        if phase == 'val' and self.class_weights is not None:
+        if phase == 'val' and self.val_sample_weights is not None:
+            accuracy = np.average(preds == labels, weights=self.val_sample_weights)
+        elif phase == 'val' and self.class_weights is not None:
             sample_weights = self.class_weights[labels.astype(np.int64)]
             accuracy = np.average(preds == labels, weights=sample_weights)
         else:
@@ -78,6 +89,10 @@ class MetricLogger:
         train_stats = self._calculate_metrics('train')
         val_stats = self._calculate_metrics('val')
         self.val_metrics['accuracy'] = val_stats['accuracy']
+        self.history['train_loss'].append(train_stats['loss'])
+        self.history['train_accuracy'].append(train_stats['accuracy'])
+        self.history['val_loss'].append(val_stats['loss'])
+        self.history['val_accuracy'].append(val_stats['accuracy'])
 
         # 记录到TensorBoard
         self._log_to_tensorboard(train_stats, val_stats)
@@ -85,6 +100,8 @@ class MetricLogger:
         # 生成可视化报告
         self._save_confusion_matrix(val_stats['cm_norm'], 'val_confusion_matrix')
         self._save_classification_report(val_stats['report'])
+        self._save_classification_metrics_chart(val_stats['report'], 'val_classification_metrics')
+        self._save_training_curves('training_curves')
         
         # 打印概要
         print(f"Epoch Summary - Train Loss: {train_stats['loss']:.4f} | Val Loss: {val_stats['loss']:.4f}")
@@ -118,6 +135,7 @@ class MetricLogger:
         if 'val' in stats:
             self._save_confusion_matrix(stats['val']['cm_norm'], 'val_confusion_matrix')
             self._save_classification_report(stats['val']['report'])
+            self._save_classification_metrics_chart(stats['val']['report'], 'val_classification_metrics')
         
         # 打印结果
         if 'val' in stats:
@@ -132,6 +150,15 @@ class MetricLogger:
         fig = self._plot_confusion_matrix(val_stats['cm_norm'])
         self.writer.add_figure('Confusion Matrix', fig, self.epoch)
         plt.close(fig)
+
+        fig = self._plot_classification_metrics(val_stats['report'])
+        self.writer.add_figure('Validation/Class Metrics', fig, self.epoch)
+        plt.close(fig)
+
+        if self.history['val_loss']:
+            fig = self._plot_training_curves()
+            self.writer.add_figure('Training/Curves', fig, self.epoch)
+            plt.close(fig)
 
     def _plot_confusion_matrix(self, cm):
         fig, ax = plt.subplots(figsize=(8,8))
@@ -148,7 +175,7 @@ class MetricLogger:
 
     def _save_confusion_matrix(self, cm, name):
         fig = self._plot_confusion_matrix(cm)
-        fig.savefig(os.path.join(self.log_dir, f'{name}.png'))
+        fig.savefig(os.path.join(self.log_dir, f'{name}.png'), bbox_inches='tight')
         plt.close(fig)
 
     def _save_classification_report(self, report):
@@ -157,3 +184,77 @@ class MetricLogger:
             for cls in self.class_names:
                 f.write(f"{cls:<10} {report[cls]['precision']:<10.2f} {report[cls]['recall']:<10.2f} {report[cls]['f1-score']:<10.2f}\n")
             f.write(f"\nOverall Accuracy: {report['accuracy']:.2%}")
+
+    def _plot_classification_metrics(self, report):
+        metrics = ['precision', 'recall', 'f1-score']
+        x = np.arange(len(self.class_names))
+        width = 0.24
+
+        fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+        for index, metric in enumerate(metrics):
+            values = [report[class_name][metric] for class_name in self.class_names]
+            axes[0].bar(x + (index - 1) * width, values, width=width, label=metric)
+
+        axes[0].set_xticks(x)
+        axes[0].set_xticklabels(self.class_names)
+        axes[0].set_ylim(0, 1.05)
+        axes[0].set_ylabel('Score')
+        axes[0].set_title('Per-Class Metrics')
+        axes[0].legend()
+        axes[0].grid(axis='y', alpha=0.25)
+
+        supports = [report[class_name]['support'] for class_name in self.class_names]
+        axes[1].bar(self.class_names, supports, color='#4C78A8')
+        axes[1].set_ylabel('Samples')
+        axes[1].set_title('Validation Sample Distribution')
+        axes[1].grid(axis='y', alpha=0.25)
+
+        fig.suptitle(f"Validation Summary | Accuracy: {report['accuracy']:.2%}")
+        fig.tight_layout()
+        return fig
+
+    def _save_classification_metrics_chart(self, report, name):
+        fig = self._plot_classification_metrics(report)
+        fig.savefig(os.path.join(self.log_dir, f'{name}.png'), bbox_inches='tight')
+        plt.close(fig)
+
+    def _plot_training_curves(self):
+        fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+        epochs = np.arange(1, len(self.history['train_loss']) + 1)
+
+        axes[0].plot(epochs, self.history['train_loss'], label='Train Loss', marker='o')
+        axes[0].plot(epochs, self.history['val_loss'], label='Val Loss', marker='o')
+        axes[0].set_title('Loss Curve')
+        axes[0].set_xlabel('Epoch')
+        axes[0].set_ylabel('Loss')
+        axes[0].grid(alpha=0.25)
+        axes[0].legend()
+
+        axes[1].plot(epochs, self.history['train_accuracy'], label='Train Accuracy', marker='o')
+        axes[1].plot(epochs, self.history['val_accuracy'], label='Val Accuracy', marker='o')
+        axes[1].set_title('Accuracy Curve')
+        axes[1].set_xlabel('Epoch')
+        axes[1].set_ylabel('Accuracy')
+        axes[1].set_ylim(0, 1.05)
+        axes[1].grid(alpha=0.25)
+        axes[1].legend()
+
+        fig.tight_layout()
+        return fig
+
+    def _save_training_curves(self, name):
+        if not self.history['train_loss']:
+            return
+        fig = self._plot_training_curves()
+        fig.savefig(os.path.join(self.log_dir, f'{name}.png'), bbox_inches='tight')
+        plt.close(fig)
+
+    def get_report_paths(self):
+        return {
+            'log_dir': self.log_dir,
+            'classification_report': os.path.join(self.log_dir, 'classification_report.txt'),
+            'confusion_matrix': os.path.join(self.log_dir, 'val_confusion_matrix.png'),
+            'classification_metrics': os.path.join(self.log_dir, 'val_classification_metrics.png'),
+            'training_curves': os.path.join(self.log_dir, 'training_curves.png')
+        }

--- a/combat/skill_ready/utils/loss.py
+++ b/combat/skill_ready/utils/loss.py
@@ -3,8 +3,45 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
+def _reduce_loss(loss, reduction):
+    if reduction == 'mean':
+        return loss.mean()
+    if reduction == 'sum':
+        return loss.sum()
+    return loss
+
+
+class CostSensitiveCrossEntropyLoss(nn.Module):
+    def __init__(self, weight=None, reduction='mean', confusion_cost=None, confusion_weight=0.0):
+        super().__init__()
+        if weight is not None:
+            self.register_buffer('weight', weight.float())
+        else:
+            self.weight = None
+
+        if confusion_cost is not None:
+            self.register_buffer('confusion_cost', confusion_cost.float())
+        else:
+            self.confusion_cost = None
+
+        self.reduction = reduction
+        self.confusion_weight = confusion_weight
+
+    def forward(self, inputs, targets):
+        log_probs = F.log_softmax(inputs, dim=1)
+        probs = log_probs.exp()
+        ce_loss = F.nll_loss(log_probs, targets, weight=self.weight, reduction='none')
+
+        if self.confusion_cost is not None and self.confusion_weight > 0:
+            confusion_penalty = (probs * self.confusion_cost[targets]).sum(dim=1)
+            ce_loss = ce_loss + self.confusion_weight * confusion_penalty
+
+        return _reduce_loss(ce_loss, self.reduction)
+
+
 class FocalLoss(nn.Module):
-    def __init__(self, alpha=1.0, gamma=2.0, weight=None, reduction='mean'):
+    def __init__(self, alpha=1.0, gamma=2.0, weight=None, reduction='mean', confusion_cost=None,
+                 confusion_weight=0.0):
         """
         Focal Loss implementation
 
@@ -18,8 +55,18 @@ class FocalLoss(nn.Module):
         super(FocalLoss, self).__init__()
         self.alpha = alpha
         self.gamma = gamma
-        self.weight = weight
+        if weight is not None:
+            self.register_buffer('weight', weight.float())
+        else:
+            self.weight = None
+
+        if confusion_cost is not None:
+            self.register_buffer('confusion_cost', confusion_cost.float())
+        else:
+            self.confusion_cost = None
+
         self.reduction = reduction
+        self.confusion_weight = confusion_weight
 
     def forward(self, inputs, targets):
         """
@@ -27,18 +74,21 @@ class FocalLoss(nn.Module):
             inputs: (N, C) where C = number of classes
             targets: (N,) where each value is 0 ≤ targets[i] ≤ C-1
         """
-        # Compute cross entropy
-        ce_loss = F.cross_entropy(inputs, targets, weight=self.weight, reduction='none')
+        log_probs = F.log_softmax(inputs, dim=1)
+        probs = log_probs.exp()
+        target_log_probs = log_probs.gather(1, targets.unsqueeze(1)).squeeze(1)
+        ce_loss = -target_log_probs
 
-        # Compute probabilities
-        pt = torch.exp(-ce_loss)
+        if self.weight is not None:
+            ce_loss = ce_loss * self.weight[targets]
+
+        pt = target_log_probs.exp()
 
         # Compute focal loss
         focal_loss = self.alpha * (1 - pt) ** self.gamma * ce_loss
 
-        if self.reduction == 'mean':
-            return focal_loss.mean()
-        elif self.reduction == 'sum':
-            return focal_loss.sum()
-        else:  # 'none'
-            return focal_loss
+        if self.confusion_cost is not None and self.confusion_weight > 0:
+            confusion_penalty = (probs * self.confusion_cost[targets]).sum(dim=1)
+            focal_loss = focal_loss + self.confusion_weight * confusion_penalty
+
+        return _reduce_loss(focal_loss, self.reduction)

--- a/combat/skill_ready/validate.py
+++ b/combat/skill_ready/validate.py
@@ -73,13 +73,11 @@ def main():
             num_workers=4,
             pin_memory=True
         )
-        err_folder_weight = float(config['training'].get('sampler', {}).get('err_folder_weight', 1.0))
         val_class_counts = get_dataset_class_counts(val_dataset, len(model_wrapper.class_names))
         val_class_weights = get_dataset_class_weights(val_dataset, len(model_wrapper.class_names))
         val_sample_weights = get_dataset_sample_weights(
             val_dataset,
-            len(model_wrapper.class_names),
-            err_folder_weight=err_folder_weight
+            len(model_wrapper.class_names)
         )
         print(
             f"Data loader统计 | 指定验证集路径: {args.val_path} | 验证样本数: {len(val_loader.dataset)} | 批次数: {len(val_loader)}")
@@ -91,7 +89,7 @@ def main():
             f"验证集评估权重 | "
             f"{' | '.join(f'{name}: {weight:.4f}' for name, weight in zip(model_wrapper.class_names, val_class_weights.tolist()))}"
         )
-        print(f"验证集难例加权系数 | _err: {err_folder_weight:.2f}")
+        print("验证集评估策略 | 仅按类别数量加权，不对 _err 额外加权")
     except KeyError as e:
         print(f"Data loading配置错误: {str(e)}")
         return

--- a/combat/skill_ready/validate.py
+++ b/combat/skill_ready/validate.py
@@ -4,7 +4,7 @@ import yaml
 import torch
 import time
 import argparse
-from core.data_loader import SkillIconDataset, get_dataset_class_counts, get_dataset_class_weights
+from core.data_loader import SkillIconDataset, get_dataset_class_counts, get_dataset_class_weights, get_dataset_sample_weights
 from core.model_builder import create_model
 from utils.logger import MetricLogger
 from torch.utils.data import DataLoader
@@ -73,8 +73,14 @@ def main():
             num_workers=4,
             pin_memory=True
         )
+        err_folder_weight = float(config['training'].get('sampler', {}).get('err_folder_weight', 1.0))
         val_class_counts = get_dataset_class_counts(val_dataset, len(model_wrapper.class_names))
         val_class_weights = get_dataset_class_weights(val_dataset, len(model_wrapper.class_names))
+        val_sample_weights = get_dataset_sample_weights(
+            val_dataset,
+            len(model_wrapper.class_names),
+            err_folder_weight=err_folder_weight
+        )
         print(
             f"Data loader统计 | 指定验证集路径: {args.val_path} | 验证样本数: {len(val_loader.dataset)} | 批次数: {len(val_loader)}")
         print(
@@ -85,6 +91,7 @@ def main():
             f"验证集评估权重 | "
             f"{' | '.join(f'{name}: {weight:.4f}' for name, weight in zip(model_wrapper.class_names, val_class_weights.tolist()))}"
         )
+        print(f"验证集难例加权系数 | _err: {err_folder_weight:.2f}")
     except KeyError as e:
         print(f"Data loading配置错误: {str(e)}")
         return
@@ -110,8 +117,10 @@ def main():
         log_dir=os.path.join("pytorch_val"),
         class_names=['c', 'n', 'y'],
         model_name=config['model']['name'],
-        class_weights=val_class_weights
+        class_weights=val_class_weights,
+        val_sample_weights=val_sample_weights
     )
+    print(f"验证报告目录: {logger.log_dir}")
 
     # 6. 推理性能测试（修复尺寸问题）
     try:
@@ -214,6 +223,11 @@ def main():
         print(f"\n验证结果 | 准确率: {logger.val_metrics['accuracy']:.2%}")
     else:
         print("Warning: 验证指标未计算，请检查数据记录")
+    report_paths = logger.get_report_paths()
+    print(f"分类报告: {report_paths['classification_report']}")
+    print(f"混淆矩阵: {report_paths['confusion_matrix']}")
+    print(f"分类指标图: {report_paths['classification_metrics']}")
+    logger.writer.close()
 
 
 if __name__ == "__main__":

--- a/combat/skill_ready/validate.py
+++ b/combat/skill_ready/validate.py
@@ -1,13 +1,30 @@
 import os
+import shutil
 import yaml
 import torch
 import time
 import argparse
-from core.data_loader import SkillIconDataset
+from core.data_loader import SkillIconDataset, get_dataset_class_counts, get_dataset_class_weights
 from core.model_builder import create_model
 from utils.logger import MetricLogger
 from torch.utils.data import DataLoader
 from utils.path_manager import get_model_paths
+
+
+def build_hard_example_path(hard_example_root, true_class_name, pred_class_name, image_path):
+    target_dir = os.path.join(hard_example_root, f"{true_class_name}_err")
+    os.makedirs(target_dir, exist_ok=True)
+
+    stem, ext = os.path.splitext(os.path.basename(image_path))
+    base_name = f"{stem}__pred_{pred_class_name}"
+    candidate_path = os.path.join(target_dir, f"{base_name}{ext}")
+    suffix = 1
+
+    while os.path.exists(candidate_path):
+        candidate_path = os.path.join(target_dir, f"{base_name}_{suffix}{ext}")
+        suffix += 1
+
+    return candidate_path
 
 
 def parse_args():
@@ -16,6 +33,7 @@ def parse_args():
                         default='configs/mobilenetv4_conv_small.yaml', type=str, required=True)
     parser.add_argument('--weights', help='Specify pth path', type=str)
     parser.add_argument('--val_path', help='Specify validation set path', default='datasets/val', type=str)
+    parser.add_argument('--hard_example_dir', help='将误判图片按真实类别导出到训练目录，如 datasets/train', type=str)
     args = parser.parse_args()
     return args
 
@@ -55,8 +73,18 @@ def main():
             num_workers=4,
             pin_memory=True
         )
+        val_class_counts = get_dataset_class_counts(val_dataset, len(model_wrapper.class_names))
+        val_class_weights = get_dataset_class_weights(val_dataset, len(model_wrapper.class_names))
         print(
             f"Data loader统计 | 指定验证集路径: {args.val_path} | 验证样本数: {len(val_loader.dataset)} | 批次数: {len(val_loader)}")
+        print(
+            f"验证集类别计数 | "
+            f"{' | '.join(f'{name}: {int(count)}' for name, count in zip(model_wrapper.class_names, val_class_counts.tolist()))}"
+        )
+        print(
+            f"验证集评估权重 | "
+            f"{' | '.join(f'{name}: {weight:.4f}' for name, weight in zip(model_wrapper.class_names, val_class_weights.tolist()))}"
+        )
     except KeyError as e:
         print(f"Data loading配置错误: {str(e)}")
         return
@@ -82,7 +110,7 @@ def main():
         log_dir=os.path.join("pytorch_val"),
         class_names=['c', 'n', 'y'],
         model_name=config['model']['name'],
-        class_weights=None
+        class_weights=val_class_weights
     )
 
     # 6. 推理性能测试（修复尺寸问题）
@@ -125,6 +153,7 @@ def main():
     print("\n开始完整验证...")
     logger.new_epoch()
     total_samples = 0
+    hard_example_count = 0
 
     # 输出文件路径
     output_file = None
@@ -158,7 +187,19 @@ def main():
                         output_file.write(f"类别置信度: {[f'{p:.8f}' for p in class_probs]}\n")
                         output_file.write("-" * 50 + "\n")
 
+                        if args.hard_example_dir and pred_class != true_class:
+                            target_path = build_hard_example_path(
+                                args.hard_example_dir,
+                                logger.class_names[true_class],
+                                logger.class_names[pred_class],
+                                image_path
+                            )
+                            shutil.copy2(image_path, target_path)
+                            hard_example_count += 1
+
         print(f"总验证样本数: {total_samples}")
+        if args.hard_example_dir:
+            print(f"已导出难例样本数: {hard_example_count} -> {args.hard_example_dir}")
     except RuntimeError as e:
         print(f"验证过程异常: {str(e)}")
         return


### PR DESCRIPTION
## Summary by Sourcery

为 skill_ready 分类器引入对困难样本感知的数据管线、代价敏感的训练与评估机制，以及改进的训练/导出工作流。

New Features:
- 在数据集中支持 *_err 困难样本文件夹，并可在采样和评估中通过配置对其进行加权提升。
- 新增可配置的代价敏感交叉熵和 focal loss，并支持在类别之间设置可选的非对称混淆惩罚。
- 提供数据集去重和训练/验证集划分脚本，以构建更干净且分层抽样（stratified）的数据集。
- 允许从已有的 PyTorch checkpoint 进行微调，并将显式选择的 .pth 权重导出为 ONNX。
- 在 PyTorch 和 ONNX 验证运行期间，支持可选地将误分类样本导出回 *_err 文件夹中。

Enhancements:
- 重构数据加载逻辑，以支持独立的训练/验证根目录、分层划分、加权采样，以及基于类别/样本统计的自动权重。
- 改进 BaseModel 中的类别权重计算，使用平滑缩放的方式基于类别计数生成权重，并使训练/验证的变换与生产环境预处理保持一致。
- 扩展训练循环，引入余弦学习率调度、warmup、早停机制，以及按 epoch 跟踪学习率和指标。
- 增强 MetricLogger，使其能够处理加权准确率，维护训练历史，并生成混淆矩阵、按类别划分的指标图表，以及训练曲线。
- 更新配置默认值和 README，记录新的数据布局、采样/加权方案、训练工作流及相关工具。
- 修改导出脚本，使其默认从 checkpoint 加载模型或从显式路径加载，并在专门的指南中记录 ONNX 导出行为。

Documentation:
- 在 README 中记录扩展后 的数据集布局，包括 *_err 文件夹、去重/划分工作流，以及困难样本的处理方式。
- 新增 export.md，用于说明 ONNX 导出行为和显式权重选择流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce hard-example-aware data pipeline, cost-sensitive training and evaluation, and improved training/export workflows for the skill_ready classifier.

New Features:
- Support *_err hard example folders in datasets with configurable upweighting in sampling and evaluation.
- Add configurable cost-sensitive cross-entropy and focal loss with optional asymmetric confusion penalties between classes.
- Provide dataset deduplication and train/validation split scripts for cleaner, stratified datasets.
- Allow fine-tuning from existing PyTorch checkpoints and exporting explicitly chosen .pth weights to ONNX.
- Enable optional export of misclassified samples back into *_err folders during PyTorch and ONNX validation runs.

Enhancements:
- Refactor data loading to support separate train/val roots, stratified splits, weighted sampling, and automatic class/sample-statistics-based weights.
- Improve BaseModel class weight computation using smoothed scaling over class counts and align train/val transforms with production preprocessing.
- Extend the training loop with cosine LR scheduling, warmup, early stopping, and per-epoch LR/metric tracking.
- Enhance MetricLogger to handle weighted accuracy, maintain training history, and generate confusion matrices, per-class metric charts, and training curves.
- Update configuration defaults and README to document the new data layout, sampling/weighting scheme, training workflow, and utilities.
- Make export script load checkpoints by default or from an explicit path and document the ONNX export behavior in a dedicated guide.

Documentation:
- Document the extended dataset layout including *_err folders, deduplication/splitting workflow, and hard-example handling in README.
- Add export.md to describe ONNX export behavior and explicit weight selection.

</details>

新功能：
- 在数据集中支持 *_err 难例文件夹，并在采样和评估过程中提供可配置的权重提升。
- 新增可配置的代价敏感交叉熵损失和 focal loss，并支持在特定类别之间设置非对称混淆惩罚。
- 引入数据集去重和训练/验证集划分工具，以保持更干净的、分层抽样的数据集。
- 支持在训练过程中从已有 checkpoint 进行微调，并将指定的 .pth 权重导出为 ONNX。
- 允许在 PyTorch 和 ONNX 验证期间，将误分类样本可选地导出回 *_err 训练文件夹中。

增强改进：
- 重构数据加载，支持独立的训练/验证根路径、分层划分、加权采样，以及自动计算类别统计信息。
- 改进 BaseModel 的类别权重计算，采用更平滑的缩放方式，并在训练和验证中使用更丰富的数据增强。
- 在训练循环中添加余弦学习率调度、warmup、早停机制以及按 epoch 记录学习率。
- 扩展 MetricLogger，支持加权准确率、历史记录追踪，并生成混淆矩阵、按类别的指标图表以及训练曲线。
- 明确并扩展 README 与新的导出文档，以说明新的工作流、加权方案和脚本。

文档：
- 在 README 中记录包含 *_err 文件夹的新数据集布局、去重与划分脚本，以及难例处理工作流。
- 新增 export.md，说明 ONNX 导出行为及显式权重选择方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 skill_ready 分类器引入对困难样本感知的数据管线、代价敏感的训练与评估机制，以及改进的训练/导出工作流。

New Features:
- 在数据集中支持 *_err 困难样本文件夹，并可在采样和评估中通过配置对其进行加权提升。
- 新增可配置的代价敏感交叉熵和 focal loss，并支持在类别之间设置可选的非对称混淆惩罚。
- 提供数据集去重和训练/验证集划分脚本，以构建更干净且分层抽样（stratified）的数据集。
- 允许从已有的 PyTorch checkpoint 进行微调，并将显式选择的 .pth 权重导出为 ONNX。
- 在 PyTorch 和 ONNX 验证运行期间，支持可选地将误分类样本导出回 *_err 文件夹中。

Enhancements:
- 重构数据加载逻辑，以支持独立的训练/验证根目录、分层划分、加权采样，以及基于类别/样本统计的自动权重。
- 改进 BaseModel 中的类别权重计算，使用平滑缩放的方式基于类别计数生成权重，并使训练/验证的变换与生产环境预处理保持一致。
- 扩展训练循环，引入余弦学习率调度、warmup、早停机制，以及按 epoch 跟踪学习率和指标。
- 增强 MetricLogger，使其能够处理加权准确率，维护训练历史，并生成混淆矩阵、按类别划分的指标图表，以及训练曲线。
- 更新配置默认值和 README，记录新的数据布局、采样/加权方案、训练工作流及相关工具。
- 修改导出脚本，使其默认从 checkpoint 加载模型或从显式路径加载，并在专门的指南中记录 ONNX 导出行为。

Documentation:
- 在 README 中记录扩展后 的数据集布局，包括 *_err 文件夹、去重/划分工作流，以及困难样本的处理方式。
- 新增 export.md，用于说明 ONNX 导出行为和显式权重选择流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce hard-example-aware data pipeline, cost-sensitive training and evaluation, and improved training/export workflows for the skill_ready classifier.

New Features:
- Support *_err hard example folders in datasets with configurable upweighting in sampling and evaluation.
- Add configurable cost-sensitive cross-entropy and focal loss with optional asymmetric confusion penalties between classes.
- Provide dataset deduplication and train/validation split scripts for cleaner, stratified datasets.
- Allow fine-tuning from existing PyTorch checkpoints and exporting explicitly chosen .pth weights to ONNX.
- Enable optional export of misclassified samples back into *_err folders during PyTorch and ONNX validation runs.

Enhancements:
- Refactor data loading to support separate train/val roots, stratified splits, weighted sampling, and automatic class/sample-statistics-based weights.
- Improve BaseModel class weight computation using smoothed scaling over class counts and align train/val transforms with production preprocessing.
- Extend the training loop with cosine LR scheduling, warmup, early stopping, and per-epoch LR/metric tracking.
- Enhance MetricLogger to handle weighted accuracy, maintain training history, and generate confusion matrices, per-class metric charts, and training curves.
- Update configuration defaults and README to document the new data layout, sampling/weighting scheme, training workflow, and utilities.
- Make export script load checkpoints by default or from an explicit path and document the ONNX export behavior in a dedicated guide.

Documentation:
- Document the extended dataset layout including *_err folders, deduplication/splitting workflow, and hard-example handling in README.
- Add export.md to describe ONNX export behavior and explicit weight selection.

</details>

</details>